### PR TITLE
Add scout flag to prioritize regex matches in directory view

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1329,6 +1329,7 @@ class scout(Command):
 
     Flags:
      -a    Automatically open a file on unambiguous match
+     -c    Move matching items to the top of the directory view
      -e    Open the selected file when pressing enter
      -f    Filter files that match the current search pattern
      -g    Interpret pattern as a glob pattern
@@ -1348,6 +1349,7 @@ class scout(Command):
     """
     # pylint: disable=bad-whitespace
     AUTO_OPEN     = 'a'
+    COLLECT       = 'c'
     OPEN_ON_ENTER = 'e'
     FILTER        = 'f'
     SM_GLOB       = 'g'
@@ -1390,6 +1392,11 @@ class scout(Command):
 
         if self.PERM_FILTER in flags:
             thisdir.filter = regex if pattern else None
+           
+        if self.COLLECT in flags:
+            def sort_by_regex(path):
+                return 0 if regex.match(path.basename) else 1
+            thisdir.files_all.sort(key=sort_by_regex)                    
 
         # clean up:
         self.cancel()


### PR DESCRIPTION
Fixes #1299

#### ISSUE TYPE

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 18.04
- Terminal emulator and version: urxvt v9.22
- Python version: 2.7.15
- Ranger version/commit: ranger-master 1.9.2
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
scout option -c collects regex matches at the top of the directory view without hiding non-matches. 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Tested with Python 2. 

